### PR TITLE
Add variable python name

### DIFF
--- a/src/sample/Main.java
+++ b/src/sample/Main.java
@@ -536,8 +536,12 @@ public class Main extends Application {
 
         try {
 
+            String pythonCmdName = "python";
+            if (System.getProperty("os.name").startsWith("Windows"))
+                pythonCmdName = "py";
+
             String line = "";
-            BufferedReader reader = new BufferedReader(new InputStreamReader(excCommand("python \".\\decoder\\TBLUdecode.py\" \"" + selectedFile.getPath() + "\" JSON")));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(excCommand(pythonCmdName + " \".\\decoder\\TBLUdecode.py\" \"" + selectedFile.getPath() + "\" JSON")));
 
             System.out.println("Running decoder");
             if(printDecoder) System.out.println("-----------------------------------------------------------");


### PR DESCRIPTION
Uses "py" instead of "python" when running with Windows

"py" is the python launcher for Windows, typically installed at C:\Windows\py.exe

It's possible to add another setting as well to force "py", "python", or "python3" as some users may have set up PATH variables differently.